### PR TITLE
Ignore short DATA_CONFIRM packets

### DIFF
--- a/lib/frame-parser.js
+++ b/lib/frame-parser.js
@@ -87,6 +87,13 @@ function(frame, reader, _options) {
   }
   frame.id = reader.nextUInt8();
   frame.dstAddrMode = reader.nextUInt8();
+  if (frame.payloadLen < 11) {
+    // For some reason, the ConBee II sends DATA_CONFIRM packets with a length
+    // of 10, which as far as I can tell are invalid.
+    console.error('Rcvd DATA_CONFIRM with invalid payLoad len of',
+                  frame.payloadLen);
+    return;
+  }
   switch (frame.dstAddrMode) {
     case 0:
       // This means that there is no addressing information included


### PR DESCRIPTION
The ConBee II sometimes sends out short
DATA_CONFIRM frames which have a payloadLen of 10
which according to the documentation is invalid.